### PR TITLE
CA-8346/Allow Boomerang tasks to be resent

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+**What's this do?**
+
+[Description of what this PR does goes here]
+
+**Why are we doing this? (w/ JIRA link if applicable)**
+
+[Quick blurb about why the code is needed and Jira link goes here]
+
+**How should this be tested?**
+
+[Description of any tests that need to be performed once merged goes here]
+
+**Are there any migrations? Post the sqlmigrate output**
+
+[Callout if there are migrartions and sqlmigrate output goes here]
+
+**Dependencies for merging? Releasing to production?**
+
+[Description of any watchouts, dependencies, or issues we should be aware of goes here]

--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,5 @@ venv.bak/
 
 # End of https://www.gitignore.io/api/macos,python
 
+.vscode/
 .envrc

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ venv.bak/
 
 
 # End of https://www.gitignore.io/api/macos,python
+
+.envrc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/aly.sivji/.virtualenvs/boomerang-dev/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/aly.sivji/.virtualenvs/boomerang-dev/bin/python"
+}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ By default, Celery jobs are acknowledged when they are started. This results in 
 
 We can configure tasks to be [acknowledged after they are completed](http://docs.celeryproject.org/en/latest/faq.html#faq-acks-late-vs-retry). This enables tasks to be resumeable if we keep track of current progress. If we leverage Boomerang has this functionality: we are able to infer the task's goal_size and keep track of our incremental progress.
 
-Would recommend using this for idemopotent tasks as a task might be run and stopped before the database is udpated.
+Would recommend using this for **idemopotent tasks** as a task might be run and stopped before the database records the updated progress.
 
 We have to inject a progress variable, `_current_progress`, into each resumeable task defintion's `perform_async()` function. Our task definition should use the `_curent_progress` to continue where it was stopped.
 
@@ -65,7 +65,7 @@ from boomerang import BoomerangTask, BoomerangFailedTask
 class SendPushNotificationsBoomerangTask(BoomerangTask):
 
     @staticmethod
-    def perform_async(job, user_ids, _current_progress, _*args, **kwargs):
+    def perform_async(job, user_ids, _current_progress, *args, **kwargs):
         user_ids = user_ids[_current_progress:]
 
         for user_id in user_ids:
@@ -74,13 +74,11 @@ class SendPushNotificationsBoomerangTask(BoomerangTask):
                 raise BoomerangFailedTask
             job.increment_progress()
 
-# this can be called as follows:
+# this can be queued as follows:
 SendPushNotificationsBoomerangTask(all_users_ids, _resumeable=True)
 ```
 
 #### Kill Resumeable Boomerang Tasks
 
-You will need to stop the task via celery.
-
-1. Find the `Job ID` using the Boomerang admin
+1. Find the `Job ID` using the Boomerang admin (`/admin/boomerang/job`)
 1. Run the following management command: `manage.py boomerang_kill_task --id #`

--- a/README.md
+++ b/README.md
@@ -8,30 +8,36 @@ Django app to provide visibility into Celery tasks.
 ## Usage
 
 ### Defining the task
+
 Each Boomerang task has an associated Job object. Jobs have states "Not yet running", "Running", "Done", and "Failed". They have a public mutator method `increment_progress()`, which increments progress towards the goal, represented by an integer (default is 1). After incrementing progress, this call `save()`s the job, but at most once per second. Calling `increment_progress()` is completely optional. The Job will still display its states regardless of progress updates.
 
 A Job instance is passed to a Boomerang Task's `perform_async()` static method, which can be used to update the state of a job. By default, the goal is set synchronously by checking the size of any lists or dicts passed in as arguments although this behaviour can be overridden by defining the `get_goal_size()` method.
 
 A Job's state is Failed if an exception is caught. To signal an intentional failure, import and raise `BoomerangFailedTask`; otherwise, the exception will be re-raised after updating the Job's state.
 
-    from boomerang import BoomerangTask, BoomerangFailedTask
+```python
+from boomerang import BoomerangTask, BoomerangFailedTask
 
-    class SendPushNotificationsBoomerangTask(BoomerangTask):
+class SendPushNotificationsBoomerangTask(BoomerangTask):
 
-        @staticmethod
-        def perform_async(job, user_ids, *args, **kwargs):
-            for user_id in user_ids:
-                # ...push notification logic...
-                if something_went_wrong:
-                    raise BoomerangFailedTask
-                job.increment_progress()
+    @staticmethod
+    def perform_async(job, user_ids, *args, **kwargs):
+        for user_id in user_ids:
+            # ...push notification logic...
+            if something_went_wrong:
+                raise BoomerangFailedTask
+            job.increment_progress()
+```
 
 The method `get_name()` can also be overridden to change the name of the Boomerang Task shown in admin.
 
 ### Calling the task
+
 To call the task, simply initialize the Boomerang Task class with the values you would like passed in to `perform_async()`:
 
-    SendPushNotificationsBoomerangTask(user_ids, request=request)
+```python
+SendPushNotificationsBoomerangTask(user_ids, request=request)
+```
 
 By default, a Boomerang Task with a goal of 1 will execute the `perform_async()` step synchronously. This can be disabled by setting `perform_sync_with_single` to `False`.
 
@@ -42,3 +48,32 @@ Overriding the `perform_sync()` method allows you to run steps synchronously for
 Setting the `celery_queue` class attribute will cause a Boomerang Task to use that specific queue. By default it is not set and will therefore use the default celery queue.
 
 If you would like to create a Boomerang Task without creating a job, you can set the class attribute `create_boomerang_job` to `False`.
+
+### Resumable Tasks
+
+By default, Celery jobs are acknowledged when they are started. This results in tasks that do not run to completion as execution is interrupted.
+
+We can configure tasks to be [acknowledged after they are completed](http://docs.celeryproject.org/en/latest/faq.html#faq-acks-late-vs-retry). This enables tasks to be resumeable if we keep track of current progress. If we leverage Boomerang has this functionality: we are able to infer the task's goal_size and keep track of our incremental progress.
+
+Would recommend using this for idemopotent tasks as a task might be run and stopped before the database is udpated.
+
+We have to inject a progress variable, `_current_progress`, into each resumeable task defintion's `perform_async()` function. Our task definition should use the `_curent_progress` to continue where it was stopped.
+
+```python
+from boomerang import BoomerangTask, BoomerangFailedTask
+
+class SendPushNotificationsBoomerangTask(BoomerangTask):
+
+    @staticmethod
+    def perform_async(job, user_ids, _current_progress, _*args, **kwargs):
+        user_ids = user_ids[:_current_progress]
+
+        for user_id in user_ids:
+            # ...push notification logic...
+            if something_went_wrong:
+                raise BoomerangFailedTask
+            job.increment_progress()
+
+# this can be called as follows:
+SendPushNotificationsBoomerangTask(all_users_ids, _resumeable=True)
+```

--- a/README.md
+++ b/README.md
@@ -77,3 +77,10 @@ class SendPushNotificationsBoomerangTask(BoomerangTask):
 # this can be called as follows:
 SendPushNotificationsBoomerangTask(all_users_ids, _resumeable=True)
 ```
+
+#### Kill Resumeable Boomerang Tasks
+
+You will need to stop the task via celery.
+
+1. Find the `Job ID` using the Boomerang admin
+1. Run the following management command: `manage.py boomerang_kill_task --id #`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class SendPushNotificationsBoomerangTask(BoomerangTask):
 
     @staticmethod
     def perform_async(job, user_ids, _current_progress, _*args, **kwargs):
-        user_ids = user_ids[:_current_progress]
+        user_ids = user_ids[_current_progress:]
 
         for user_id in user_ids:
             # ...push notification logic...

--- a/boomerang/boomerang.py
+++ b/boomerang/boomerang.py
@@ -149,22 +149,7 @@ def boomerang_task(module, name, job_id, *args, **kwargs):
 
 @shared_task(acks_late=True, reject_on_worker_lost=True)
 def resumeable_boomerang_task(module, name, job_id, *args, **kwargs):
-    """
-    Resumable Boomerang tasks allow us to continue where we left off.
-
-    By default, Celery jobs are acknowledged when they are started. This
-    results in tasks that do not run to completion as execution is interrupted.
-
-    We can configure tasks to be acknowledged when they are completed. This
-    enables tasks to be resumeable if we keep track of current progress.
-    Boomerang has this functionality: we are able to infer the task's goal_size
-    as well as keep a count of our incremental progress.
-
-    Note: we'll have to inject a progress variable, `_current_progress`,  into
-    each resumeable task defintion's `perform_async()` function. Our function
-    should use the `_curent_progress` to continue where it was stopped.
-
-    Would recommend using this for idemopotent tasks.
+    """Resumable Boomerang tasks that track current progress
 
     @param module: String module path where the Boomerang Task class is
     @param name: String name of the Boomerang Task class

--- a/boomerang/boomerang.py
+++ b/boomerang/boomerang.py
@@ -14,6 +14,12 @@ from .exceptions import BoomerangFailedTask
 
 
 class BoomerangTask(object):
+    """Boomerang tasks provide introspection into Celery jobs.
+
+    Boomerang jobs can be resumed by passing `_resumeable=True`. Parameters are
+    prefixed with underscore to avoid a namespace clash with parameters
+    passed into Boomerang tasks.
+    """
 
     create_boomerang_job = True
     perform_sync_with_single = True
@@ -167,10 +173,13 @@ def resumeable_boomerang_task(module, name, job_id, *args, **kwargs):
     if job_id:
         job = Job.objects.get(id=job_id)
         job.set_status(Job.RUNNING)
+        current_progress = job.progress
+    else:
+        current_progress = 0
 
     # Perform the asynchronous code for the Boomerang Task
     try:
-        boomerang_task.perform_async(job, _current_progress=job.progress, *args, **kwargs)
+        boomerang_task.perform_async(job, _current_progress=current_progress, *args, **kwargs)
     except Exception as e:
         # Mark the Job as failed
         if job:

--- a/boomerang/boomerang.py
+++ b/boomerang/boomerang.py
@@ -37,8 +37,10 @@ class BoomerangTask(object):
 
         return ' '.join(words).title()
 
-    def __init__(self, resumeable=False, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         from .models import Job
+
+        resumeable = kwargs.pop("_resumeable", None)
 
         # Run synchronous code
         self.perform_sync(*args, **kwargs)
@@ -47,7 +49,10 @@ class BoomerangTask(object):
 
         if self.perform_sync_with_single and goal == 1:
             # Perform asynchronous code synchronously if there is only one item
-            self.perform_async(job, *args, **kwargs)
+            if resumeable:
+                self.perform_async(job, _current_progress=0, *args, **kwargs)
+            else:
+                self.perform_async(job, *args, **kwargs)
         else:
             # Create a Boomerang Job
             if self.create_boomerang_job:

--- a/boomerang/boomerang.py
+++ b/boomerang/boomerang.py
@@ -98,7 +98,7 @@ class BoomerangTask(object):
         pass
 
 
-@shared_task
+@shared_task(acks_late=True, reject_on_worker_lost=True)
 def boomerang_task(module, name, job_id, *args, **kwargs):
     """
     @param module: String module path where the Boomerang Task class is

--- a/boomerang/management/commands/boomerang_kill_task.py
+++ b/boomerang/management/commands/boomerang_kill_task.py
@@ -1,0 +1,22 @@
+from celery.task.control import revoke
+from django.core.management.base import BaseCommand
+
+from boomerang.models import Job
+
+
+class Command(BaseCommand):
+    help = 'Kill Boomerang task'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--id',
+            dest='job_id',
+            help='Boomerang job ID to kill',
+            required=True,
+            type=int,
+        )
+
+    def handle(self, *args, **kwargs):
+        job_id = kwargs["job_id"]
+        job = Job.objects.get(pk=job_id)
+        revoke(job.celery_task_id, terminate=True)

--- a/boomerang/management/commands/boomerang_kill_task.py
+++ b/boomerang/management/commands/boomerang_kill_task.py
@@ -24,4 +24,4 @@ class Command(BaseCommand):
         job.set_status(Job.FAILED)
         job.save()
 
-        self.stdout.write("Killed task -- Boomerang ID %s Celery ID %s" % (job_id, celery_task_id))
+        self.stdout.write("Killed task -- Boomerang ID %s Celery ID %s" % (job_id, job.celery_task_id))

--- a/boomerang/management/commands/boomerang_kill_task.py
+++ b/boomerang/management/commands/boomerang_kill_task.py
@@ -19,4 +19,9 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         job_id = kwargs["job_id"]
         job = Job.objects.get(pk=job_id)
+
         revoke(job.celery_task_id, terminate=True)
+        job.set_status(Job.FAILED)
+        job.save()
+
+        self.stdout.write("Killed task -- Boomerang ID %s Celery ID %s" % (job_id, celery_task_id))

--- a/boomerang/tests/tasks.py
+++ b/boomerang/tests/tasks.py
@@ -22,3 +22,23 @@ class FailingBoomerangTask(BoomerangTask):
                 raise ValueError("Cannot handle value of 5")
             if job:
                 job.increment_progress()
+
+
+class ResumeableBoomerangTask(BoomerangTask):
+
+    @staticmethod
+    def perform_async(job, integers, _current_progress):
+        for _ in integers:
+            if job:
+                job.increment_progress()
+
+
+class ResumableFailingBoomerangTask(BoomerangTask):
+
+    @staticmethod
+    def perform_async(job, integers, _current_progress):
+        for i in integers:
+            if i == 5:
+                raise ValueError("Cannot handle value of 5")
+            if job:
+                job.increment_progress()

--- a/boomerang/tests/test_boomerang_task.py
+++ b/boomerang/tests/test_boomerang_task.py
@@ -5,7 +5,12 @@ from django.test import TestCase
 
 from boomerang.boomerang import BoomerangTask
 from boomerang.models import Job
-from boomerang.tests.tasks import FailingBoomerangTask, SimpleBoomerangTask
+from boomerang.tests.tasks import (
+    FailingBoomerangTask,
+    ResumeableBoomerangTask,
+    ResumableFailingBoomerangTask,
+    SimpleBoomerangTask,
+)
 
 
 class BoomerangTaskTestCase(TestCase):
@@ -34,6 +39,35 @@ class BoomerangTaskTestCase(TestCase):
     def test_failing_boomerang_task(self):
         # Execute a Boomerang task that will fail part of the way through
         FailingBoomerangTask(list(range(10)))
+
+        # Verify that the job has been marked as failed and that the progress does not match the goal
+        job = Job.objects.get()
+        self.assertEqual(job.status, Job.FAILED)
+        self.assertLess(job.progress, job.goal)
+
+
+class ResumableBoomerangTaskTestCase(TestCase):
+    def test_simple_resumeable_boomerang_task(self):
+        # Execute a simple Boomerang task
+        num_integers = 5
+        ResumeableBoomerangTask(list(range(num_integers)), _resumeable=True)
+
+        # Verify that the job is marked as complete, and the progress matches the goal
+        job = Job.objects.get()
+        self.assertEqual(job.goal, num_integers)
+        self.assertEqual(job.status, Job.DONE)
+        self.assertEqual(job.progress, num_integers)
+
+    def test_small_resumeable_boomerang_task_runs_synchronously(self):
+        # Execute a Boomerang task with a goal size of 1
+        ResumeableBoomerangTask(list(range(1)), _resumeable=True)
+
+        # Verify that no Boomerang jobs were created, since the job was run fully synchronously
+        self.assertFalse(Job.objects.exists())
+
+    def test_failing_resumeable_boomerang_task(self):
+        # Execute a Boomerang task that will fail part of the way through
+        ResumableFailingBoomerangTask(list(range(10)), _resumeable=True)
 
         # Verify that the job has been marked as failed and that the progress does not match the goal
         job = Job.objects.get()

--- a/boomerang/tests/test_boomerang_task.py
+++ b/boomerang/tests/test_boomerang_task.py
@@ -6,9 +6,7 @@ from django.test import TestCase
 from boomerang.boomerang import BoomerangTask
 from boomerang.models import Job
 from boomerang.tests.tasks import (
-    FailingBoomerangTask,
-    ResumeableBoomerangTask,
-    ResumableFailingBoomerangTask,
+    FailingBoomerangTask, ResumeableBoomerangTask, ResumableFailingBoomerangTask,
     SimpleBoomerangTask,
 )
 


### PR DESCRIPTION
**What's this do?**

Boomerang tasks fail silently when workers are restarted as Celery acknowledges the task when it is pulled off the queue. By changing some celery configuration settings (thx [docs](http://docs.celeryproject.org/en/latest/faq.html#faq-acks-late-vs-retry) and @peymanmortazavi), we can have Celery acknowledge once the task has been completed. This results in the task being resent to our workers if the task is not completed. By keeping track of incremental progress, we can continue where the task left off.

To create tasks we can resume, pass in `_resumeable=True` to the Boomerang constructor. You will also need to accept the `_current_progress` parameter in your task definition function. Also added a management command to kill Boomerang jobs. Additional details in `README.md`.

 **Why are we doing this? (w/ JIRA link if applicable)**

https://infoscout.atlassian.net/browse/CA-8346

 **How should this be tested?**

Created unit tests for this but everything is run synchronously, so it's hard to simulate restarting celery processes. Did test this on localhost and in staging via `sudo service celeryd-default stop / start`, works as expected.

 **Are there any migrations? Post the sqlmigrate output**

n/a

 **Dependencies for merging? Releasing to production?**

 n/a